### PR TITLE
feat: Add human-readable ISO Timestamp to output file

### DIFF
--- a/src/main/java/edu/usf/sas/pal/muser/model/MusicAnalysisModel.java
+++ b/src/main/java/edu/usf/sas/pal/muser/model/MusicAnalysisModel.java
@@ -18,7 +18,9 @@ package edu.usf.sas.pal.muser.model;
 
 import java.util.List;
 import edu.usf.sas.pal.muser.model.MusicAnalysisModel.AudioData.VolumeData;
+import edu.usf.sas.pal.muser.utils.DateTimeUtil;
 import edu.usf.sas.pal.muser.utils.StringUtils;
+import org.joda.time.DateTime;
 
 public class MusicAnalysisModel {
 
@@ -1021,6 +1023,7 @@ public class MusicAnalysisModel {
             "record_id",
             "player_event_type",
             "ui_event_type",
+            "event_current_time_in_iso",
             "event_current_time_in_milliseconds",
             "event_nano_time",
             "event_seek_position_in_milliseconds",
@@ -1222,6 +1225,7 @@ public class MusicAnalysisModel {
                 recordId,
                 eventPlayerType,
                 eventUiType,
+                DateTimeUtil.getDateAndTimeFromMillis(eventCurrentTimeMs),
                 StringUtils.valueOf(eventCurrentTimeMs),
                 StringUtils.valueOf(eventNanoTime),
                 StringUtils.valueOf(eventSeekPositionMs),

--- a/src/main/java/edu/usf/sas/pal/muser/model/MusicAnalysisModel.java
+++ b/src/main/java/edu/usf/sas/pal/muser/model/MusicAnalysisModel.java
@@ -1023,7 +1023,6 @@ public class MusicAnalysisModel {
             "record_id",
             "player_event_type",
             "ui_event_type",
-            "event_current_time_in_iso",
             "event_current_time_in_milliseconds",
             "event_nano_time",
             "event_seek_position_in_milliseconds",
@@ -1076,6 +1075,7 @@ public class MusicAnalysisModel {
             "device_info_sdk_version_int",
             "device_info_talk_back_enabled",
             "device_info_timestamp",
+            "event_current_time_in_iso_utc"
     };
 
     public Long getSeekPositionMs() {
@@ -1225,7 +1225,6 @@ public class MusicAnalysisModel {
                 recordId,
                 eventPlayerType,
                 eventUiType,
-                DateTimeUtil.getDateAndTimeFromMillis(eventCurrentTimeMs),
                 StringUtils.valueOf(eventCurrentTimeMs),
                 StringUtils.valueOf(eventNanoTime),
                 StringUtils.valueOf(eventSeekPositionMs),
@@ -1277,7 +1276,8 @@ public class MusicAnalysisModel {
                 deviceInfoSdkVersion,
                 StringUtils.valueOf(deviceInfoSdkVersionInt),
                 StringUtils.valueOf(deviceInfoTalkBackEnabled),
-                deviceInfoTimestamp
+                deviceInfoTimestamp,
+                DateTimeUtil.getDateAndTimeFromMillis(eventCurrentTimeMs)
         };
     }
 }

--- a/src/main/java/edu/usf/sas/pal/muser/utils/DateTimeUtil.java
+++ b/src/main/java/edu/usf/sas/pal/muser/utils/DateTimeUtil.java
@@ -1,5 +1,9 @@
 package edu.usf.sas.pal.muser.utils;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
 public class DateTimeUtil {
 
     /**
@@ -13,6 +17,20 @@ public class DateTimeUtil {
             if (dateStartMillis < dateEndMillis) return true;
             else return false;
         } else return false;
+    }
+
+    /**
+     * Gets the time in the string ISO 8601 UTC format from the provided epoch time
+     * @param millis
+     * @return the time in the string ISO 8601 UTC format from the provided epoch time
+     */
+    public static String getDateAndTimeFromMillis(Long millis) {
+        if (millis == null) return "";
+        Date date = new Date(millis);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        // Set time zone to GMT to obtain timestamp as UTC date
+        sdf.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
+        return sdf.format(date);
     }
 
 }

--- a/src/main/java/edu/usf/sas/pal/muser/utils/DateTimeUtil.java
+++ b/src/main/java/edu/usf/sas/pal/muser/utils/DateTimeUtil.java
@@ -1,8 +1,6 @@
 package edu.usf.sas.pal.muser.utils;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
 
 public class DateTimeUtil {
 
@@ -25,12 +23,11 @@ public class DateTimeUtil {
      * @return the time in the string ISO 8601 UTC format from the provided epoch time
      */
     public static String getDateAndTimeFromMillis(Long millis) {
-        if (millis == null) return "";
-        Date date = new Date(millis);
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        // Set time zone to GMT to obtain timestamp as UTC date
-        sdf.setTimeZone(TimeZone.getTimeZone("Etc/UTC"));
-        return sdf.format(date);
+        if (millis == null) {
+            return "";
+        } else {
+            return Instant.ofEpochMilli(millis).toString();
+        }
     }
 
 }

--- a/src/test/java/edu/usf/sas/pal/muser/test/DateTimeUtilsTest.java
+++ b/src/test/java/edu/usf/sas/pal/muser/test/DateTimeUtilsTest.java
@@ -58,10 +58,10 @@ public class DateTimeUtilsTest {
         // UTC time: Sunday, August 11, 2019 3:36:22.198 AM
         long testDate4 = 1565494582198L;
 
-        assertEquals("2019-08-09T20:29:42Z", DateTimeUtil.getDateAndTimeFromMillis(testDate1));
-        assertEquals("2019-08-09T23:49:42Z", DateTimeUtil.getDateAndTimeFromMillis(testDate2));
-        assertEquals("2019-08-10T07:09:52Z", DateTimeUtil.getDateAndTimeFromMillis(testDate3));
-        assertEquals("2019-08-11T03:36:22Z", DateTimeUtil.getDateAndTimeFromMillis(testDate4));
+        assertEquals("2019-08-09T20:29:42.198Z", DateTimeUtil.getDateAndTimeFromMillis(testDate1));
+        assertEquals("2019-08-09T23:49:42.198Z", DateTimeUtil.getDateAndTimeFromMillis(testDate2));
+        assertEquals("2019-08-10T07:09:52.198Z", DateTimeUtil.getDateAndTimeFromMillis(testDate3));
+        assertEquals("2019-08-11T03:36:22.198Z", DateTimeUtil.getDateAndTimeFromMillis(testDate4));
     }
 
 }

--- a/src/test/java/edu/usf/sas/pal/muser/test/DateTimeUtilsTest.java
+++ b/src/test/java/edu/usf/sas/pal/muser/test/DateTimeUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests utilities for date-time validation
@@ -39,6 +40,28 @@ public class DateTimeUtilsTest {
         assertFalse(DateTimeUtil.validateDatesProvided(dateRange6[0], dateRange6[1]));
         assertFalse(DateTimeUtil.validateDatesProvided(dateRange7[0], dateRange7[1]));
 
+    }
+
+    /**
+     * Given a time stamp in milliseconds, verify that the function
+     * getDateAndTimeFromMillis return a UTC date formatted in the format
+     * "yyyy-MM-dd'T'HH:mm:ss'Z'"
+     */
+    @Test
+    public  void testGetDateAndTimeFromMillis() {
+        // UTC time: Friday, August 9, 2019 8:29:42.198 PM
+        long testDate1 = 1565382582198L;
+        // UTC time: Friday, August 9, 2019 11:49:42.198 PM
+        long testDate2 = 1565394582198L;
+        // UTC time: Saturday, August 10, 2019 7:09:52.198 AM
+        long testDate3 = 1565420992198L;
+        // UTC time: Sunday, August 11, 2019 3:36:22.198 AM
+        long testDate4 = 1565494582198L;
+
+        assertEquals("2019-08-09T20:29:42Z", DateTimeUtil.getDateAndTimeFromMillis(testDate1));
+        assertEquals("2019-08-09T23:49:42Z", DateTimeUtil.getDateAndTimeFromMillis(testDate2));
+        assertEquals("2019-08-10T07:09:52Z", DateTimeUtil.getDateAndTimeFromMillis(testDate3));
+        assertEquals("2019-08-11T03:36:22Z", DateTimeUtil.getDateAndTimeFromMillis(testDate4));
     }
 
 }


### PR DESCRIPTION
Made necessary changes to display ISO timestamp in the CSV file on export for the `eventCurrentTimeMs` column.

Closes https://github.com/CUTR-at-USF/muser-firebase-export/issues/15.